### PR TITLE
feat/jh-실제 인증 기능이 완성되기 전까지 Mock 인증 흐름을 기반으로 개발 가능하도록 지원

### DIFF
--- a/api-test/produst-api.http
+++ b/api-test/produst-api.http
@@ -1,0 +1,2 @@
+### 상품 단건 조회 API
+GET localhost:8080/api/products/2

--- a/api-test/produst-api.http
+++ b/api-test/produst-api.http
@@ -1,2 +1,2 @@
 ### 상품 단건 조회 API
-GET localhost:8080/api/products/2
+GET localhost:8080/api/products/1

--- a/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
@@ -10,13 +10,16 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
-@EnableWebSecurity
+@EnableWebSecurity //스프링 시큐리티 활성화
 public class SecurityConfig {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
+                // 폼 로그인 비활성화 (기본 로그인 화면 제거)
                 .formLogin(AbstractHttpConfigurer::disable)
+                // HTTP Basic 인증 비활성화
                 .httpBasic(AbstractHttpConfigurer::disable)
+                // 세션을 사용하지 않고 JWT 등 stateless 방식 사용 예정
                 .sessionManagement(it -> it.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .build();
     }

--- a/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
@@ -1,0 +1,23 @@
+package com.example.surveyapp.global.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(it -> it.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .build();
+    }
+}

--- a/src/main/java/com/example/surveyapp/mockExample/ProductController.java
+++ b/src/main/java/com/example/surveyapp/mockExample/ProductController.java
@@ -14,12 +14,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/products")
 public class ProductController {
+    // 상품 ID로 단건 조회 (mock 인증 포함)
     @GetMapping("{id}")
     ResponseEntity<String> getProductById(
             @PathVariable("id") Long id,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
+        // 인증된 사용자 정보 로그로 출력 (디버깅용)
         log.info("userDetails username: {}, roles: {}", userDetails.getUsername(), userDetails.getAuthorities());
+
+        // 일단은 상품 ID를 문자열로 응답 (예제용)
         return ResponseEntity.ok(String.valueOf(id));
     }
 }

--- a/src/main/java/com/example/surveyapp/mockExample/ProductController.java
+++ b/src/main/java/com/example/surveyapp/mockExample/ProductController.java
@@ -1,0 +1,25 @@
+package com.example.surveyapp.mockExample;
+
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/products")
+public class ProductController {
+    @GetMapping("{id}")
+    ResponseEntity<String> getProductById(
+            @PathVariable("id") Long id,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        log.info("userDetails username: {}, roles: {}", userDetails.getUsername(), userDetails.getAuthorities());
+        return ResponseEntity.ok(String.valueOf(id));
+    }
+}

--- a/src/test/java/com/example/surveyapp/mockExample/ProductControllerTest.java
+++ b/src/test/java/com/example/surveyapp/mockExample/ProductControllerTest.java
@@ -12,25 +12,25 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
-@WebMvcTest(controllers = ProductController.class)
-@AutoConfigureMockMvc(addFilters = false)
+@WebMvcTest(controllers = ProductController.class) // ProductController만 테스트용으로 로딩
+@AutoConfigureMockMvc(addFilters = false) // Security 필터 적용 안함 (mock 인증만 사용)
 public class ProductControllerTest {
     @Autowired
-    private MockMvc mockMvc;
+    private MockMvc mockMvc; // API 요청 테스트 도구
 
     @Test
-    @WithMockUser(username = "안지현", roles = "ADMIN")
-    @DisplayName("내가 등록한 상품 상세 조회")
+    @WithMockUser(username = "안지현", roles = "ADMIN") // 가짜 사용자로 인증된 상태를 시뮬레이션
+    @DisplayName("내가 등록한 상품 상세 조회") // 테스트 설명 (테스트 리포트에서 보임)
     void getProducts() throws Exception {
         // Given
         Long productId = 1L;
 
-        // When
+        // When: /api/products/1 호출
         // localhost:8080/api/products/1
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/products/{id}", productId)
         );
 
-        // Then
+        // Then: 결과 콘솔에 출력
         resultActions.andDo(print());
     }
 }

--- a/src/test/java/com/example/surveyapp/mockExample/ProductControllerTest.java
+++ b/src/test/java/com/example/surveyapp/mockExample/ProductControllerTest.java
@@ -1,0 +1,36 @@
+package com.example.surveyapp.mockExample;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+@WebMvcTest(controllers = ProductController.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class ProductControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithMockUser(username = "안지현", roles = "ADMIN")
+    @DisplayName("내가 등록한 상품 상세 조회")
+    void getProducts() throws Exception {
+        // Given
+        Long productId = 1L;
+
+        // When
+        // localhost:8080/api/products/1
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.get("/api/products/{id}", productId)
+        );
+
+        // Then
+        resultActions.andDo(print());
+    }
+}


### PR DESCRIPTION
## 개요
Spring Security 기반 인증 기능이 아직 구현되지 않은 상태에서 다른 개발자들이 인증 API 의존 없이 개발을 진행할 수 있도록  
Mock 인증 환경을 구성하고 예시를 확인할 수 있게 만들었습니다.

## 주요 변경 사항
- `ProductController` 생성
  - `@AuthenticationPrincipal`로 로그인 유저 정보 받는 구조
  - GET `/api/products/{id}` 요청 처리
- `ProductControllerTest` 작성
  - `@WithMockUser`를 이용한 mock 인증 테스트
  - `MockMvc` 기반 요청 검증
- `SecurityConfig` 설정
  - `formLogin`, `httpBasic` 비활성화
  - `SessionCreationPolicy.STATELESS` 적용
- 인증 객체가 없을 경우 예외 방지를 위한 null 체크 추가

## 목적
- 실제 인증 기능이 완성되기 전까지 Mock 인증 흐름을 기반으로 개발 가능하도록 지원
- 팀원들이 개발 시 인증 없이도 테스트 가능

## 기타
- 이후 실제 인증(JWT 등) 적용 시 해당 mock 흐름은 제거 예정입니다.