### PR TITLE
config: JWT 기반 인증/인가 설정 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,9 +38,11 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // jwt
-//    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
-//    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
-//    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.5'
+    compileOnly group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.12.5'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.12.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.12.5'
+
     testRuntimeOnly 'com.h2database:h2'
 
 // query-dsl 5.1.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+services:
+  mysql:
+    image: mysql:8.0
+    container_name: survey-mysql
+    restart: always
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root-password
+      MYSQL_DATABASE: survey_app
+      MYSQL_USER: dev-user
+      MYSQL_PASSWORD: dev-password
+    command: >
+      --character-set-server=utf8mb4
+      --collation-server=utf8mb4_unicode_ci
+      --lower_case_table_names=1

--- a/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
@@ -1,30 +1,66 @@
 package com.example.surveyapp.global.config;
 
-
+import com.example.surveyapp.global.filter.JwtFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
-@EnableWebSecurity //스프링 시큐리티 활성화
+@EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true) // @Secured, @PreAuthorize 사용 가능
+@RequiredArgsConstructor
 public class SecurityConfig {
+
     @Bean
-    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    private final JwtFilter jwtFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
                 .csrf(AbstractHttpConfigurer::disable)
-                // 폼 로그인 비활성화 (기본 로그인 화면 제거)
-                .formLogin(AbstractHttpConfigurer::disable)
-                // HTTP Basic 인증 비활성화
                 .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/**").permitAll()
-                        .anyRequest().authenticated())
-                // 세션을 사용하지 않고 JWT 등 stateless 방식 사용 예정
-                .sessionManagement(it -> it.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                        // 비회원 허용
+                        .requestMatchers(
+                                "/api/auth/register",
+                                "/api/auth/login",
+                                "/api/auth/logout",
+                                "/api/auth/refresh",
+                                "/error"
+                        ).permitAll()
+
+                        // 관리자 권한 필요
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+
+                        // 유저 권한 필요
+                        .requestMatchers("/api/user/**").hasRole("USER")
+
+                        // 나머지 인증 필요
+                        .anyRequest().authenticated()
+                )
+                //UsernamePasswordAuthenticationFilter : 스프링 시큐리티에서 기본적으로
+                // username, password와 같은 입력값을 이용해서 인증을 시도하고, 인증된 사용자 정보를
+                // UsernamePasswrodAuthenticationToken으로 구성해서 SecurityContextHodler에 저장하는
+                // UsernamePasswordAuthenticationFilter
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+
+
                 .build();
     }
 }

--- a/src/main/java/com/example/surveyapp/global/filter/JwtFilter.java
+++ b/src/main/java/com/example/surveyapp/global/filter/JwtFilter.java
@@ -1,0 +1,83 @@
+package com.example.surveyapp.global.filter;
+
+import com.example.surveyapp.domain.user.domain.model.User;
+import com.example.surveyapp.domain.user.domain.repository.UserRepository;
+import com.example.surveyapp.global.response.exception.UnauthorizedException;
+import com.example.surveyapp.global.security.jwt.CustomUserDetails;
+import com.example.surveyapp.global.security.jwt.JwtUtil;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.apache.tomcat.util.http.parser.Authorization;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    /**
+     *
+     * 1. Authorization Header가 있는지 검증(해당 요청이 인증 항목을 포함하고 있는지)
+     * 2. Authorization Header가 Bearer 타입인지 검증(JWT 기반 인증 방식인지)
+     * 3. 우리가 발급한 입장권인지
+     *     - Jwt를 만들때 사용했던 sercret-key를 기반으로 해석했을 때, 해석이 된다면 우리가 발급한 JWT 구나
+     * 4. 우리가 발급한 입정권이라면 유효기간은 지나지 않았는지
+     * 5. 우리가 발급한 입장권이고, 유효기간이 지나지 않은 사용가능한 입장권(jwt)라면 입장권 검사(필터링) 이후 비지니스 로직 혹은 규칙등을 실행하는데 필요한 인증된 사용자 정보를 제공하기 위해서 SecurityContextHolder라는 공간에 jwt로 부터 추출한 인증된 사용자 정보(CusomUserDetilas)를 저장
+     *     - 인증된 사용자 정보가 필요한 비지니스 로직 처리 부는 @AuthenticationPrincipal과 같은 어노테이션을 이용해서 SecurityContextHolder에 접근이 가능
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain
+    ) throws ServletException, IOException {
+        // 1. Authorization Header가 있는지 검증(해당 요청이 인증 항목을 포함하고 있는지)
+        String bearerJwt = request.getHeader("Authorization");
+
+        // 2. Authorization Header가 Bearer 타입인지 검증(JWT 기반 인증 방식인지)
+        if (bearerJwt == null || !bearerJwt.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String jwt = jwtUtil.substringToken(bearerJwt);
+
+        // 3. 우리가 발급한 입장권인지 유효한 입장권인지
+        // - Jwt를 만들때 사용했던 sercret-key를 기반으로 해석했을 때, 해석이 된다면 우리가 발급한 JWT 구나
+        // - 유효 기간, JWT의 형식 검증등을 포함
+        if (!jwtUtil.validateToken(jwt)) {
+            throw new UnauthorizedException("유효하지 않은 JWT 토큰입니다.");
+        }
+
+        // 5. 우리가 발급한 입장권이고, 유효기간이 지나지 않은 사용가능한 입장권(jwt)라면 입장권 검사(필터링) 이후
+        // 비지니스 로직 혹은 규칙등을 실행하는데 필요한 인증된 사용자 정보를 제공하기 위해
+        // SecurityContextHolder라는 공간에 jwt로 부터 추출한 인증된 사용자 정보(CusomUserDetilas)를 저장
+        // - 인증된 사용자 정보가 필요한 비지니스 로직 처리 부는
+        // @AuthenticationPrincipal과 같은 어노테이션을 이용해서 SecurityContextHolder에 접근이 가능
+        String subject = jwtUtil.extractUserId(jwt);
+        Long userId = Long.parseLong(subject);
+
+        // SecurityContextHolder라는 공간에 jwt로 부터 추출한 인증된 사용자 정보(CusomUserDetilas)를 저장하기 위해
+        // 1. 회원 테이블에서 인증된 사용자 정보를 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UnauthorizedException("해당 유저가 없습니다."));
+
+        // 2. 인증된 사용자 정보를 인증된 사용자 정보가 필요한 비지니스 로직 처리 부에 접근 가능하도록 하기 위해
+        // SecurityContextHolder에 저장하기 위한 타입으로 변환: CustomUserDetails, UsernamePasswordAuthenticationToken
+        CustomUserDetails customUserDetails = new CustomUserDetails(user);
+        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(
+                customUserDetails, null, customUserDetails.getAuthorities()
+        );
+        SecurityContextHolder.getContext().setAuthentication(authenticationToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/surveyapp/global/response/exception/UnauthorizedException.java
+++ b/src/main/java/com/example/surveyapp/global/response/exception/UnauthorizedException.java
@@ -1,0 +1,7 @@
+package com.example.surveyapp.global.response.exception;
+
+public class UnauthorizedException extends RuntimeException {
+    public UnauthorizedException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/surveyapp/global/security/jwt/CustomUserDetails.java
+++ b/src/main/java/com/example/surveyapp/global/security/jwt/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package com.example.surveyapp.global.security.jwt;
+
+import com.example.surveyapp.domain.user.domain.model.User;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@ToString
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final String name;
+    private final String nickname;
+    private final String email;
+
+    @JsonIgnore
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(User user) {
+        this.id = user.getId();
+        this.name = user.getName();
+        this.nickname = user.getNickname();
+        this.email = user.getEmail();
+        this.password = user.getPassword();
+        this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name()));
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override public String getPassword() { return password; }
+
+    @Override public String getUsername() { return nickname; }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+
+    @Override public boolean isAccountNonLocked() { return true; }
+
+    @Override public boolean isCredentialsNonExpired() { return true; }
+
+    @Override public boolean isEnabled() { return true; }
+}

--- a/src/main/java/com/example/surveyapp/global/security/jwt/JwtUtil.java
+++ b/src/main/java/com/example/surveyapp/global/security/jwt/JwtUtil.java
@@ -1,0 +1,109 @@
+package com.example.surveyapp.global.security.jwt;
+
+import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtParser;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private static final String BEARER_PREFIX = "Bearer ";
+//    private static final long TOKEN_TIME = 30 * 60 * 1000L; // 30분
+
+    @Value("${jwt.secret.key}")
+    private String secretKey;
+
+    @Value("${jwt.access-token.expiration.mills}")
+    private long TOKEN_TIME;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        byte[] stringToByte = secretKey.getBytes(StandardCharsets.UTF_8);
+        byte[] bytes = Base64.getEncoder().encode(stringToByte);
+        key = Keys.hmacShaKeyFor(bytes);
+    }
+
+    /**
+     * JWT를 이용한 입장권(요청 권한)을 생성하기 위해 jjwt-0.12.5 라이브러리를 이용
+     * Jwts.builder().compact를 이용해서 JWT(Json Web Token)
+     * setSubject(), claim, issuedAt, expiration을 이용해서 jwt 발급에 필요한 정보를 설정할 수 있다.
+     *  - setsubject : 발급 주체(회원 번호)
+     *  - claim : jwt에 대한 추가 정보(회원 권한)
+     *  - issuedAt: 토큰 발급 시간(현재 시간)
+     *  - expiration: 토큰 만료 시간(발급 시간으로 부터 30분)
+     * 해당 jwt를 만들때, 외부에서 생성이 불가능하도록, 반드시 우리시스템에서만 만들수 있도록 하는 장치 = key
+     * - signWith: 우리만 생성할 수 있는 유일한 key
+     */
+    public String createAccessToken(Long userId, UserRoleEnum userRole) {
+        Date now = new Date();
+
+        return BEARER_PREFIX + Jwts.builder()
+                .setSubject(String.valueOf(userId)) // id : 1
+                .claim("role", userRole.name()) // role: SURVEYEE
+                .issuedAt(now) // 2025-07-26T16:21:47
+                .expiration(new Date(now.getTime() + TOKEN_TIME)) // 발급일로부터 30분
+                // 다른 시스템에서 우리시스템에 들어오기 위해 필요한 입장권을 만들지 못하도록 하는 장치
+                .signWith(key)
+                .compact();
+    }
+
+
+    /**
+     * 헤더에서 "Bearer <토큰>" 형식에서 토큰만 추출
+     */
+
+    public String substringToken(String tokenValue) {
+        if (StringUtils.hasText(tokenValue) && tokenValue.startsWith(BEARER_PREFIX)) {
+            return tokenValue.substring(7);
+        }
+        throw new IllegalStateException("JWT 토큰이 필요합니다.");
+    }
+
+    /**
+     * JWT 토큰에서 모든 클레임을 추출합니다.
+     * - jjwt의 Jwts.parser() 메서드를 호출하면 String jwt의 내부 값을 추출할 수 있음
+     * - Jwts.parser()를 호출하기 위해서는 생성한 key와 동일한 key로 해석이 가능해야함
+     *   - verifyWith: 생성에 사용했던 동일한 key를 설정
+     * - Jwts. parser 내부의 메서드를 이용해서 발급 주체인 subject 혹은 jwt의 추가 정보가 구성된 claims의 값에 접근이 가능
+     *   - parseSignedClaims() -> claims에 접근
+     *   - getSubject() -> 발급 주체인 subject 값에 접근
+     */
+    public Claims extractAllClaims(String token) {
+        JwtParser parser =  Jwts.parser()
+                .verifyWith(key)
+                .build();
+
+        return parser
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * 토큰 자체의 유효성 검증 메서드
+     */
+
+    public boolean validateToken(String token) {
+        try {
+            Claims claims = extractAllClaims(token);
+            return !claims.getExpiration().before(new Date());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    public String extractUserId(String token) {
+        return extractAllClaims(token).getSubject();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -36,4 +36,4 @@ jwt:
     key: ${JWT_SECRET_KEY}
   access-token:
       expiration:
-        mills: 1000
+        mills: 1800000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,6 @@ logging:
 jwt:
   secret:
     key: ${JWT_SECRET_KEY}
+  access-token:
+      expiration:
+        mills: 1000

--- a/src/test/java/com/example/surveyapp/global/JwtUtilTest.java
+++ b/src/test/java/com/example/surveyapp/global/JwtUtilTest.java
@@ -1,0 +1,63 @@
+package com.example.surveyapp.global;
+
+import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
+import com.example.surveyapp.global.security.jwt.JwtUtil;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Date;
+
+@DisplayName("security:JWT")
+@SpringBootTest
+@ActiveProfiles("test")
+public class JwtUtilTest {
+
+    @Autowired
+    private JwtUtil jwtUtil;
+
+
+    @Test
+    public void jjwtCreateTokenTest() {
+        String jwt = Jwts.builder()
+                .subject("1L")
+                .claim("roel", "USER")
+                .issuedAt(new Date())
+                .expiration(new Date())
+                .compact();
+        System.out.println(jwt);
+    }
+
+    @Test
+    @DisplayName("토큰을 생성한다.")
+    public void createToken() {
+        // Given
+        Long userId = 1L;
+        UserRoleEnum role = UserRoleEnum.SURVEYEE;
+
+        // When
+        String jwt = jwtUtil.createAccessToken(userId, role);
+
+        // Then
+        System.out.println("jwt : " + jwt);
+    }
+
+    @Test
+    @DisplayName("토큰을 검증한다.")
+    public void verifyToken() throws InterruptedException {
+        Long userId = 1L;
+        UserRoleEnum role = UserRoleEnum.SURVEYEE;
+        String accessToken = jwtUtil.createAccessToken(userId, role);
+        String jwt = jwtUtil.substringToken(accessToken);
+
+        // When
+        Claims claims = jwtUtil.extractAllClaims(jwt);
+        Assertions.assertThat(claims.getSubject()).isEqualTo(String.valueOf(userId));
+        Assertions.assertThat(claims.get("role")).isEqualTo(role.name());
+    }
+}

--- a/src/test/java/com/example/surveyapp/global/JwtUtilTest.java
+++ b/src/test/java/com/example/surveyapp/global/JwtUtilTest.java
@@ -26,7 +26,7 @@ public class JwtUtilTest {
     public void jjwtCreateTokenTest() {
         String jwt = Jwts.builder()
                 .subject("1L")
-                .claim("roel", "USER")
+                .claim("role", "USER")
                 .issuedAt(new Date())
                 .expiration(new Date())
                 .compact();


### PR DESCRIPTION
## 상세 내용

- JWT AccessToken 생성, 파싱, 검증 로직 (JwtUtil)
- HTTP 요청 시 토큰 검증 및 인증 저장 필터 구현 (JwtFilter)
- 인증 유저 객체(CustomUserDetails) 생성 및 SecurityContext 등록
- @AuthenticationPrincipal 기반 인증 유저 접근 처리
- JwtUtil 단위 테스트 (토큰 생성/파싱/검증) 작성 완료

- application.yml의 토큰 만료시간(TOKEN_TIME)을 1000ms → 1800000ms(30분)로 수정
- JwtUtilTest 내 "roel" → "role" 오타 수정으로 클레임 검증 정상화
<br/>

## 주의 사항

<br/>

Close #{112}