### PR TITLE
시큐리티 설정에서 Role 문자열 하드코딩 제거

### DIFF
--- a/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.surveyapp.global.config;
 
+import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
 import com.example.surveyapp.global.filter.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,12 +21,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtFilter jwtFilter;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
-    private final JwtFilter jwtFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -46,10 +47,13 @@ public class SecurityConfig {
                         ).permitAll()
 
                         // 관리자 권한 필요
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/**").hasRole(UserRoleEnum.ADMIN.getRole())
 
-                        // 유저 권한 필요
-                        .requestMatchers("/api/user/**").hasRole("USER")
+                        // 유저 권한 필요 (설문 참여자, 출제자 모두 허용)
+                        .requestMatchers("/api/user/**").hasAnyRole(
+                                UserRoleEnum.SURVEYEE.getRole(),
+                                UserRoleEnum.SURVEYOR.getRole()
+                        )
 
                         // 나머지 인증 필요
                         .anyRequest().authenticated()


### PR DESCRIPTION
## 상세 내용
- SecurityConfig 내 `hasRole`, `hasAnyRole` 부분의 하드코딩된 문자열("ADMIN", "USER") 제거
- `UserRoleEnum.getRole()`을 활용해 Enum 기반 Role 처리로 변경
- 시스템에서 실제 사용하는 `SURVEYEE`, `SURVEYOR`, `ADMIN` 권한과 일치하도록 수정

<br/>

## 주의 사항

<br/>

Close #{137}