### PR TITLE
CustomUserDetails에 userRole 필드 추가, ADMIN 권한 선택 불가 처리

### DIFF
--- a/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
+++ b/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
@@ -33,4 +33,6 @@ public class RegisterRequestDto {
     @Size(min = 1, max = 10, message = "별명은 1~10자여야 합니다.")
     private String nickname;
 
+    @NotNull(message = "회원 유형은 필수입니다.")
+    private UserRoleEnum userRole;
 }

--- a/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
+++ b/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
@@ -1,5 +1,9 @@
 package com.example.surveyapp.domain.user.controller.dto;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;

--- a/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
+++ b/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
@@ -1,9 +1,7 @@
 package com.example.surveyapp.domain.user.controller.dto;
 
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
-import jakarta.validation.constraints.Size;
+import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
+import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
+++ b/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
@@ -37,4 +37,9 @@ public class RegisterRequestDto {
 
     @NotNull(message = "회원 유형은 필수입니다.")
     private UserRoleEnum userRole;
+
+    @AssertTrue(message = "회원 유형은 SURVEYEE 또는 SURVEYOR만 가능합니다.")
+    public boolean isValidUserRole() {
+        return userRole == UserRoleEnum.SURVEYEE || userRole == UserRoleEnum.SURVEYOR;
+    }
 }

--- a/src/main/java/com/example/surveyapp/domain/user/service/UserService.java
+++ b/src/main/java/com/example/surveyapp/domain/user/service/UserService.java
@@ -47,7 +47,7 @@ public class UserService {
                 encodedPassword,
                 requestDto.getName(),
                 requestDto.getNickname(),
-                UserRoleEnum.SURVEYEE
+                requestDto.getUserRole()
         );
 
         userRepository.save(user);

--- a/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.surveyapp.global.config;
 
+import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
 import com.example.surveyapp.global.filter.JwtFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,12 +21,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final JwtFilter jwtFilter;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
-    private final JwtFilter jwtFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -46,10 +47,13 @@ public class SecurityConfig {
                         ).permitAll()
 
                         // 관리자 권한 필요
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/admin/**").hasRole(UserRoleEnum.ADMIN.getRole())
 
-                        // 유저 권한 필요
-                        .requestMatchers("/api/user/**").hasRole("USER")
+                        // 유저 권한 필요 (설문 참여자, 출제자 모두 허용)
+                        .requestMatchers("/api/user/**").hasAnyRole(
+                                UserRoleEnum.SURVEYEE.getRole(),
+                                UserRoleEnum.SURVEYOR.getRole()
+                        )
 
                         // 나머지 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/com/example/surveyapp/global/security/jwt/CustomUserDetails.java
+++ b/src/main/java/com/example/surveyapp/global/security/jwt/CustomUserDetails.java
@@ -1,6 +1,7 @@
 package com.example.surveyapp.global.security.jwt;
 
 import com.example.surveyapp.domain.user.domain.model.User;
+import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 import lombok.ToString;
@@ -19,6 +20,7 @@ public class CustomUserDetails implements UserDetails {
     private final String name;
     private final String nickname;
     private final String email;
+    private final UserRoleEnum userRole;
 
     @JsonIgnore
     private final String password;
@@ -30,6 +32,7 @@ public class CustomUserDetails implements UserDetails {
         this.nickname = user.getNickname();
         this.email = user.getEmail();
         this.password = user.getPassword();
+        this.userRole = user.getUserRole();
         this.authorities = List.of(new SimpleGrantedAuthority("ROLE_" + user.getUserRole().name()));
     }
 


### PR DESCRIPTION
## 상세 내용
- CustomUserDetails 클래스에 UserRoleEnum userRole필드 추가
- 생성자에서 user.getUserRole()을 직접 주입하여 권한 문자열 파싱 없이 활용 가능하도록 개선

- ADMIN 권한 선택 불가 처리 (@AssertTrue 검증 추가)
<br/>

## 주의 사항

<br/>

Close #{137}