### PR TITLE
test: RegisterRequestDto 유효성 검사 테스트 코드 추가

### DIFF
--- a/src/test/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDtoTest.java
+++ b/src/test/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDtoTest.java
@@ -1,0 +1,52 @@
+package com.example.surveyapp.domain.user.controller.dto;
+
+
+import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
+import jakarta.validation.*;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RegisterRequestDtoTest {
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    void 회원_역할이_SURVEYEE_또는_SURVEYOR_이면_성공() {
+        RegisterRequestDto dto = new RegisterRequestDto(
+                "test@example.com",
+                "Password1!",
+                "Password1!",
+                "Jihyun",
+                "ji",
+                UserRoleEnum.SURVEYEE // 또는 SURVEYOR
+        );
+
+        Set<ConstraintViolation<RegisterRequestDto>> violations = validator.validate(dto);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    void 회원_역할이_ADMIN이면_유효성_검사_실패() {
+        RegisterRequestDto dto = new RegisterRequestDto(
+                "test@example.com",
+                "Password1!",
+                "Password1!",
+                "Jihyun",
+                "ji",
+                UserRoleEnum.ADMIN
+        );
+
+        Set<ConstraintViolation<RegisterRequestDto>> violations = validator.validate(dto);
+
+        assertThat(violations).anyMatch(v -> v.getMessage().equals("회원 유형은 SURVEYEE 또는 SURVEYOR만 가능합니다."));
+    }
+}


### PR DESCRIPTION
## 상세 내용
- RegisterRequestDto에 대한 단위 테스트 코드 추가
- 회원 유형(userRole)에 대해 @AssertTrue 검증 수행
- SURVEYEE, SURVEYOR : 유효
- ADMIN : 유효하지 않음
<br/>

## 주의 사항
ADMIN 입력 시 검증 실패 메시지 확인 (`회원 유형은 SURVEYEE 또는 SURVEYOR만 가능합니다.`)
Postman에서도 정상적으로 검증 동작 확인 완료
<br/>

Close #{이슈_번호}