### PR TITLE
Issues/141 모든 API 응답을 공통 응답 포맷으로 감싸는 ResponseBodyAdvice 구현

### DIFF
--- a/src/main/java/com/example/surveyapp/domain/survey/controller/SurveyController.java
+++ b/src/main/java/com/example/surveyapp/domain/survey/controller/SurveyController.java
@@ -27,31 +27,31 @@ public class SurveyController {
     //설문 생성
     @PostMapping
     @PreAuthorize("hasAnyRole('ADMIN','SURVEYOR')")
-    public ResponseEntity<ApiResponse<SurveyResponseDto>> createSurvey(
+    public ResponseEntity<SurveyResponseDto> createSurvey(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody @Valid SurveyCreateRequestDto requestDto
     ){
         Long userId = userDetails.getId();
         SurveyResponseDto responseDto = surveyService.createSurvey(userId, requestDto);
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(new ApiResponse<>(true, "설문이 생성되었습니다.", responseDto));
+        return ResponseEntity.status(HttpStatus.CREATED).body(responseDto);
     }
 
     //설문 목록 조회(정렬 없이 삭제된 설문만 제외)
     @GetMapping
-    public ResponseEntity<ApiResponse<PageSurveyResponseDto<SurveyResponseDto>>> getSurveys(
+    public ResponseEntity<PageSurveyResponseDto<SurveyResponseDto>> getSurveys(
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size
     ){
         PageSurveyResponseDto<SurveyResponseDto> pagedSurveys = surveyService.getSurveys(page, size);
 
-        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>(true, "설문 목록을 조회했습니다.", pagedSurveys));
+        return ResponseEntity.status(HttpStatus.OK).body(pagedSurveys);
     }
 
     //설문 상세정보 수정
     @PatchMapping("/{surveyId}")
     @PreAuthorize("hasAnyRole('ADMIN','SURVEYOR')")
-    public ResponseEntity<ApiResponse<SurveyResponseDto>> updateSurvey(
+    public ResponseEntity<SurveyResponseDto> updateSurvey(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long surveyId,
             @Valid @RequestBody SurveyUpdateRequestDto requestDto
@@ -59,13 +59,13 @@ public class SurveyController {
         Long userId = userDetails.getId();
         SurveyResponseDto responseDto = surveyService.updateSurvey(userId, surveyId, requestDto);
 
-        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>(true, "설문이 수정되었습니다.", responseDto));
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
     //설문 상태 변경(NOT_STARTED -> IN_PROGRESS, IN_PROGRESS -> PAUSED, PAUSED -> IN_PROGRESS, IN_PROGRESS -> DONE)
     @PatchMapping("/{surveyId}/status")
     @PreAuthorize("hasAnyRole('ADMIN','SURVEYOR')")
-    public ResponseEntity<ApiResponse<SurveyStatusResponseDto>> updateSurveyStatus(
+    public ResponseEntity<SurveyStatusResponseDto> updateSurveyStatus(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long surveyId,
             @Valid @RequestBody SurveyStatusUpdateRequestDto requestDto
@@ -73,20 +73,20 @@ public class SurveyController {
         Long userId = userDetails.getId();
         SurveyStatusResponseDto responseDto = surveyService.updateSurveyStatus(userId, surveyId, requestDto);
 
-        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>(true, "설문 상태가 변경되었습니다.", responseDto));
+        return ResponseEntity.status(HttpStatus.OK).body(responseDto);
     }
 
     //설문 삭제
     @DeleteMapping("/{surveyId}")
     @PreAuthorize("hasAnyRole('ADMIN','SURVEYOR')")
-    public ResponseEntity<ApiResponse<Void>> deleteSurvey(
+    public ResponseEntity<Void> deleteSurvey(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long surveyId
     ){
         Long userId = userDetails.getId();
         surveyService.deleteSurvey(userId, surveyId);
 
-        return ResponseEntity.status(HttpStatus.OK).body(new ApiResponse<>(true, "설문이 삭제되었습니다.", null));
+        return ResponseEntity.status(HttpStatus.OK).body(null);
     }
 
     //설문 통계 조회

--- a/src/main/java/com/example/surveyapp/global/advice/GlobalResponseBodyAdvice.java
+++ b/src/main/java/com/example/surveyapp/global/advice/GlobalResponseBodyAdvice.java
@@ -1,0 +1,59 @@
+package com.example.surveyapp.global.advice;
+
+import com.example.surveyapp.global.response.ApiResponse;
+import com.example.surveyapp.global.response.exception.ErrorResponseDto;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+import java.util.Map;
+
+@ControllerAdvice
+public class GlobalResponseBodyAdvice implements ResponseBodyAdvice<Object> {
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body, MethodParameter returnType, MediaType selectedContentType,
+            Class<? extends HttpMessageConverter<?>> selectedConverterType,
+            ServerHttpRequest request, ServerHttpResponse response
+    ){
+//        if(response instanceof ServletServerHttpResponse servletResponse){
+//            int status = servletResponse.getServletResponse().getStatus();
+//            if(status >= 400){
+//                return body;
+//            }
+//        }
+
+        //spring 기본 에러 응답
+        if(body instanceof Map map){
+            if (map.containsKey("status") && map.containsKey("error")) {
+                return body;
+            }
+        }
+
+        //exception handler에서 반환한 ErrorResponseDto (커스텀에러)
+        if(body instanceof ErrorResponseDto){
+            return ApiResponse.fail(((ErrorResponseDto) body).getMessage(), body);
+        }
+
+        //이미 ApiResponse로 감싸서 반환하고 있을 때
+        if(body instanceof ApiResponse<?>){
+            return body;
+        }
+
+        return new ApiResponse<>(true, "성공", body);
+    }
+
+
+}

--- a/src/main/java/com/example/surveyapp/global/response/exception/ErrorResponseDto.java
+++ b/src/main/java/com/example/surveyapp/global/response/exception/ErrorResponseDto.java
@@ -3,6 +3,7 @@ package com.example.surveyapp.global.response.exception;
 import ch.qos.logback.core.spi.ErrorCodes;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
 @Getter
@@ -17,5 +18,9 @@ public class ErrorResponseDto {
         this.errorCode = errorCode.name();
         this.message = message;
     }
-
+    public ErrorResponseDto(HttpStatus httpStatus, String message){
+        this.status = httpStatus.value();
+        this.errorCode = httpStatus.getReasonPhrase();
+        this.message = message;
+    }
 }

--- a/src/main/java/com/example/surveyapp/global/response/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/surveyapp/global/response/exception/GlobalExceptionHandler.java
@@ -2,16 +2,29 @@ package com.example.surveyapp.global.response.exception;
 
 import com.example.surveyapp.global.response.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.servlet.View;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+    private final View error;
+
+    public GlobalExceptionHandler(View error) {
+        this.error = error;
+    }
+
     @ExceptionHandler(CustomException.class)
-    public ResponseEntity<ApiResponse<ErrorResponseDto>> handleCustomException(CustomException e) {
+    public ResponseEntity<ErrorResponseDto> handleCustomException(CustomException e) {
 
         ErrorCode errorCode = e.getErrorCode();
         ErrorResponseDto errorResponseDto = new ErrorResponseDto(errorCode, e.getMessage());
@@ -19,8 +32,65 @@ public class GlobalExceptionHandler {
         log.warn("[클라이언트 예외 발생] {} - {}", errorCode.name(), e.getMessage());
 
         return ResponseEntity
-                .status(errorCode.getStatus())
-                .contentType(MediaType.APPLICATION_JSON)
-                .body(ApiResponse.fail(errorResponseDto.getMessage(), errorResponseDto));
+                .status(errorResponseDto.getStatus())
+                .body(errorResponseDto);
     }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodArgumentNotValidException(
+            MethodArgumentNotValidException e
+    ){
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+        //요청 필드 에러 메시지 리스트
+        List errorMessages = e.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(error -> error.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        //모든 메시지 하나로 합침
+        String errorMessage = String.join(", ", errorMessages);
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+            httpStatus,
+            errorMessage
+        );
+
+        return ResponseEntity
+                .status(httpStatus)
+                .body(errorResponseDto);
+    }
+
+    @ExceptionHandler(HandlerMethodValidationException.class)
+    public ResponseEntity<ErrorResponseDto> handleMethodValidationException(HandlerMethodValidationException e){
+        HttpStatus httpStatus = HttpStatus.BAD_REQUEST;
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                httpStatus,
+                "Parameter 값이 잘못되었습니다."
+        );
+
+        return ResponseEntity
+                .status(httpStatus)
+                .body(errorResponseDto);
+
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDto> handleUnknownException(Exception e){
+        HttpStatus httpStatus = HttpStatus.INTERNAL_SERVER_ERROR;
+        log.error("[예외 발생] : ", e);
+
+        ErrorResponseDto errorResponseDto = new ErrorResponseDto(
+                httpStatus,
+                e.getMessage()
+        );
+
+        return ResponseEntity
+                .status(httpStatus)
+                .body(errorResponseDto);
+    }
+
+
 }


### PR DESCRIPTION
## 상세 내용

ResponseBodyAdvice로 성공, 실패 응답 모두 감싸도록 구현했습니다
GlobalExceptionHandler에서 원래 handle하던 customexception, validation exception, 예상치못한 예외를 다루도록 수정했고,
ErrorResponseDto만 반환하도록 수정했습니다.

SurveyController에 적용해 두었으니 확인부탁드립니다!

<br/>

## 주의 사항

<br/>

Close #141 