### PR TITLE
Fix: JSON 응답 한글 깨짐 현상 및 ObjectMapper 구조 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ ext {
 }
 
 dependencies {
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
+++ b/src/main/java/com/example/surveyapp/domain/user/controller/dto/RegisterRequestDto.java
@@ -8,10 +8,12 @@ import com.example.surveyapp.domain.user.domain.model.UserRoleEnum;
 import jakarta.validation.constraints.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor
 public class RegisterRequestDto {
     @NotBlank
     @Email(message = "이메일 형식이 올바르지 않습니다.")

--- a/src/main/java/com/example/surveyapp/global/config/JacksonConfig.java
+++ b/src/main/java/com/example/surveyapp/global/config/JacksonConfig.java
@@ -1,0 +1,17 @@
+package com.example.surveyapp.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule()); // LocalDateTime 직렬화 지원
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/example/surveyapp/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/surveyapp/global/security/handler/CustomAccessDeniedHandler.java
@@ -6,15 +6,20 @@ import com.example.surveyapp.global.response.exception.ErrorResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import java.io.IOException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+
 @Component
+@RequiredArgsConstructor
 public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
 
     @Override
     public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
@@ -25,7 +30,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
     private void writeErrorResponse(HttpServletResponse response, ErrorResponseDto error) throws IOException {
         response.setStatus(HttpStatus.FORBIDDEN.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        new ObjectMapper().writeValue(response.getWriter(), ApiResponse.fail(error.getMessage(), error));
+        objectMapper.writeValue(response.getWriter(), ApiResponse.fail(error.getMessage(), error));
     }
 }
 

--- a/src/main/java/com/example/surveyapp/global/security/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/surveyapp/global/security/handler/CustomAccessDeniedHandler.java
@@ -29,7 +29,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 
     private void writeErrorResponse(HttpServletResponse response, ErrorResponseDto error) throws IOException {
         response.setStatus(HttpStatus.FORBIDDEN.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(), ApiResponse.fail(error.getMessage(), error));
     }
 }

--- a/src/main/java/com/example/surveyapp/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/surveyapp/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -29,8 +29,10 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     private void writeErrorResponse(HttpServletResponse response, ErrorResponseDto error) throws IOException {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setContentType("application/json;charset=UTF-8");
         objectMapper.writeValue(response.getWriter(), ApiResponse.fail(error.getMessage(), error));
     }
 }
+
+
 

--- a/src/main/java/com/example/surveyapp/global/security/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/surveyapp/global/security/handler/CustomAuthenticationEntryPoint.java
@@ -6,15 +6,21 @@ import com.example.surveyapp.global.response.exception.ErrorResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import java.io.IOException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
+
 @Component
+@RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         ErrorResponseDto errorResponse = new ErrorResponseDto(HttpStatus.UNAUTHORIZED, "인증이 필요합니다.");
@@ -24,7 +30,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     private void writeErrorResponse(HttpServletResponse response, ErrorResponseDto error) throws IOException {
         response.setStatus(HttpStatus.UNAUTHORIZED.value());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        new ObjectMapper().writeValue(response.getWriter(), ApiResponse.fail(error.getMessage(), error));
+        objectMapper.writeValue(response.getWriter(), ApiResponse.fail(error.getMessage(), error));
     }
 }
 


### PR DESCRIPTION
## 상세 내용
ObjectMapper를 직접 생성하지 않고, Spring Bean으로 주입받도록 리팩토링
- ObjectMapper를 new 하지 않고 DI 받도록 개선

CustomAccessDeniedHandler에서 응답 Content-Type을 application/json;charset=UTF-8로 설정하여 한글 깨짐 현상 해결
- 기존 한글 응답 메시지가 ???로 깨지는 현상이 있었고 UTF-8 charset을 명시해 해결

--- 
테스트
- Authorization 헤더 제거 > 401 Unauthorized 응답 확인
- SURVEYEE가 관리자 기능 접근 > 403 Forbidden 응답 확인
- 응답 JSON의 한글 메시지가 ???가 아닌 정상 출력되는지 확인

## 주의 사항

<br/>

Close #{229}