### PR TITLE
fix: invalid oauth2 client google login button url

### DIFF
--- a/src/main/java/com/example/surveyapp/domain/user/domain/model/User.java
+++ b/src/main/java/com/example/surveyapp/domain/user/domain/model/User.java
@@ -16,9 +16,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
-@ToString
 @Entity
 @Getter
 @Table(name = "users")
@@ -37,7 +35,7 @@ public class User extends BaseEntity {
 	@Column(nullable = false, length = 10)
 	private String name;
 
-	@Column(nullable = false, unique = true, length = 10)
+	@Column(nullable = false, unique = true)
 	private String nickname;
 
 	@Column(nullable = false)

--- a/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/surveyapp/global/config/SecurityConfig.java
@@ -63,9 +63,7 @@ public class SecurityConfig {
 					// OAuth2 엔드포인트 허용
 					"/oauth2/**",
 					"/login/oauth2/code/**",
-					"/oauth2/authorization/**",
 
-					"/써마일.o-r.kr/**",
 					"/index.html/**",
 					"/"
 				).permitAll()

--- a/src/main/java/com/example/surveyapp/global/security/oauth/CustomOauth2UserService.java
+++ b/src/main/java/com/example/surveyapp/global/security/oauth/CustomOauth2UserService.java
@@ -70,7 +70,12 @@ public class CustomOauth2UserService extends DefaultOAuth2UserService {
 				provider,
 				providerId
 			);
-			log.info("Created user for google: {}", created);
+			log.info(
+				"Created user for google: [email: {}, name: {}, nickname: {}, userRole: {},  provider: {}, providerId: {}, password: {}]",
+				created.getEmail(), created.getName(), created.getNickname(),
+				created.getUserRole(), created.getProvider(), created.getProviderId(),
+				created.getPassword()
+			);
 			return userRepository.save(created);
 		});
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -63,6 +63,6 @@ jwt:
   secret:
     key: ${JWT_SECRET_KEY}
   access-token:
-      expiration:
-        access-token: 1800000 # 30 minutes
-        refresh-token: 1209600000 # 14 days
+    expiration:
+      access-token: 1800000 # 30 minutes
+      refresh-token: 1209600000 # 14 days

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -37,13 +37,9 @@
 
 <h2>써마일에 오신 것을 환영합니다!</h2>
 
-<!-- 구글 OAuth 로그인 URL로 연결 -->
-<button class="google"
-        onclick="location.href='https://accounts.google.com/o/oauth2/v2/auth?client_id=327848907069-5vcnae83kl65h92emqnqhm36b2gtg70s.apps.googleusercontent.com&redirect_uri=http://localhost:8080/login/oauth2/code/google&response_type=code&scope=email%20profile'">
-    <!--        onclick="location.href='https://accounts.google.com/o/oauth2/v2/auth?client_id=327848907069-5vcnae83kl65h92emqnqhm36b2gtg70s.apps.googleusercontent.com&redirect_uri=https://surmile.o-r.kr/login/oauth2/code/google&response_type=code&scope=email%20profile'">-->
+<button class="google" onclick="location.href='/oauth2/authorization/google'">
     Google 로그인
 </button>
-
 
 <!-- Kakao 로그인 (테스트용) -->
 <button class="kakao" onclick="alert('Kakao 로그인 테스트')">


### PR DESCRIPTION
- edit user nickname length constraint 10 to 255 cause google social login callback nickname data

- chore social login allow endpoint policy to security config

## 상세 내용

<br/>

## 주의 사항

<br/>

Close #{이슈_번호}